### PR TITLE
fix: change stimuli image URLS to relative

### DIFF
--- a/src/data/stimuli.ts
+++ b/src/data/stimuli.ts
@@ -22,27 +22,27 @@ export interface Stimulus {
 export const STIMULI_SET: Stimulus[] = [
   {
     id: "test_pair_1",
-    honestImage: "/stimuli/test_honest.png",
-    deceptiveImage: "/stimuli/test_deceptive.png ",
+    honestImage: "./stimuli/test_honest.png",
+    deceptiveImage: "./stimuli/test_deceptive.png ",
   },
   {
     id: "test_pair_2",
-    honestImage: "/stimuli/test_honest.png",
-    deceptiveImage: "/stimuli/test_deceptive.png ",
+    honestImage: "./stimuli/test_honest.png",
+    deceptiveImage: "./stimuli/test_deceptive.png ",
   },
   {
     id: "test_pair_3",
-    honestImage: "/stimuli/test_honest.png",
-    deceptiveImage: "/stimuli/test_deceptive.png ",
+    honestImage: "./stimuli/test_honest.png",
+    deceptiveImage: "./stimuli/test_deceptive.png ",
   },
   {
     id: "test_pair_4",
-    honestImage: "/stimuli/test_honest.png",
-    deceptiveImage: "/stimuli/test_deceptive.png ",
+    honestImage: "./stimuli/test_honest.png",
+    deceptiveImage: "./stimuli/test_deceptive.png ",
   },
   {
     id: "test_pair_5",
-    honestImage: "/stimuli/test_honest.png",
-    deceptiveImage: "/stimuli/test_deceptive.png ",
+    honestImage: "./stimuli/test_honest.png",
+    deceptiveImage: "./stimuli/test_deceptive.png ",
   },
 ];


### PR DESCRIPTION
change image URLs of stimuli to relative so they can work on GitHub pages