### PR TITLE
chore(feat): participant progress bar

### DIFF
--- a/src/Study.tsx
+++ b/src/Study.tsx
@@ -1,3 +1,4 @@
+import { AppShell } from "@mantine/core";
 import { useState } from "react";
 import { StudyController } from "./features/study/StudyController";
 
@@ -27,6 +28,13 @@ export default function Study() {
   });
 
   return (
-    <StudyController session={participantSession} hasTaken={hasTakenSurvey} />
+    <AppShell>
+      <AppShell.Main>
+        <StudyController
+          session={participantSession}
+          hasTaken={hasTakenSurvey}
+        />
+      </AppShell.Main>
+    </AppShell>
   );
 }

--- a/src/features/study/StudyController.tsx
+++ b/src/features/study/StudyController.tsx
@@ -1,4 +1,4 @@
-import { Loader } from "@mantine/core";
+import { Box, Container, LoadingOverlay, Stack } from "@mantine/core";
 import { useState } from "react";
 import {
   fetchNextPair,
@@ -7,6 +7,7 @@ import {
 } from "../../lib/stimulus";
 import { Landing } from "./Landing";
 import { Results } from "./Results";
+import { StudyProgress } from "./StudyProgress";
 import { Trial } from "./Trial";
 
 interface StudyControllerProps {
@@ -32,9 +33,12 @@ export function StudyController({ session }: StudyControllerProps) {
   // Loading state for async operations
   const [loading, setLoading] = useState<boolean>(false);
   // Current stage in study flow
-  const [stage, setStage] = useState<"landing" | "survey" | "complete">(
+  const [stage, setStage] = useState<"landing" | "survey" | "results">(
     "landing",
   );
+
+  const [trial, setTrial] = useState<number>(0);
+  const [totalTrials, setTotalTrials] = useState<number>(0);
   const [stimulus, setStimulus] = useState<StimulusPair | null>(null);
 
   /**
@@ -47,7 +51,18 @@ export function StudyController({ session }: StudyControllerProps) {
       throw new Error("cannot submit answer for invalid stimulus");
     }
     await submitResponse(session, stimulus, choice);
-    setStimulus(await fetchNextPair(session));
+    if (trial < totalTrials) {
+      const next = await fetchNextPair(session);
+      if (next) {
+        setStimulus(next);
+        setTrial(trial + 1);
+      } else {
+        setStage("results");
+      }
+    } else {
+      setStage("results");
+    }
+
     setLoading(false);
   };
 
@@ -57,37 +72,38 @@ export function StudyController({ session }: StudyControllerProps) {
     setStimulus(nextPair);
     if (nextPair) {
       setStage("survey");
+      setTrial(1);
+      setTotalTrials(
+        nextPair.sets_remaining > 20 ? 20 : nextPair.sets_remaining,
+      );
     } else {
-      setStage("complete");
+      setStage("results");
     }
     setLoading(false);
   };
 
-  // Show loader while submitting (prevents multiple API calls)
-  if (loading) {
-    return (
-      <Loader
-        size="xl"
-        style={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-        }}
-      />
-    );
-  }
+  let page;
 
-  // Show landing page initially
   if (stage === "landing") {
-    return <Landing handleStart={() => handleStart()} />;
+    page = <Landing handleStart={() => handleStart()} />;
+  } else if (stage === "survey" && stimulus) {
+    page = <Trial stimulus={stimulus} onSelect={handleSelect}></Trial>;
+  } else {
+    page = <Results session={session}></Results>;
   }
 
-  // Show survey flow
-  if (stage === "survey" && stimulus) {
-    return <Trial stimulus={stimulus} onSelect={handleSelect}></Trial>;
-  }
-
-  // Show results page when done
-  return <Results session={session}></Results>;
+  return (
+    <Stack>
+      <Container maw="80%" miw="60%" p="lg">
+        <StudyProgress
+          num_trials={totalTrials}
+          stage={stage === "survey" ? trial : stage}
+        ></StudyProgress>
+      </Container>
+      <Box pos="relative">
+        <LoadingOverlay visible={loading}></LoadingOverlay>
+        {page}
+      </Box>
+    </Stack>
+  );
 }

--- a/src/features/study/StudyProgress.tsx
+++ b/src/features/study/StudyProgress.tsx
@@ -1,0 +1,58 @@
+import { Box, Stepper } from "@mantine/core";
+
+interface StudyProgressProps {
+  /** Total number of trials the participant will complete */
+  num_trials: number;
+
+  /** Current stage or question number */
+  stage: "landing" | "results" | number;
+}
+
+/**
+ * Shows current progress of participant in study flow, breaking down into
+ * invidual questions during the survey stage.
+ * @component
+ */
+export function StudyProgress({ num_trials, stage }: StudyProgressProps) {
+  let active;
+  if (typeof stage === "number") {
+    active = 1;
+  } else if (stage === "landing") {
+    active = 0;
+  } else {
+    active = 2;
+  }
+
+  const questions = [];
+  questions.push(<Stepper.Step label="Questions"></Stepper.Step>);
+  for (let i = 1; i < num_trials; i++) {
+    questions.push(<Stepper.Step></Stepper.Step>);
+  }
+
+  // Show individual question numbers when in the trials phase
+  if (typeof stage === "number" && questions.length > 0) {
+    return (
+      <Box>
+        <Stepper
+          active={stage - 1}
+          allowNextStepsSelect={false}
+          iconPosition="right"
+          styles={{ steps: { justifyContent: "center" } }}
+        >
+          {questions}
+        </Stepper>
+      </Box>
+    );
+  }
+
+  // Otherwise show progress of overall flow
+  return (
+    <Box>
+      <Stepper active={active} allowNextStepsSelect={false}>
+        <Stepper.Step label="Instructions"></Stepper.Step>
+        <Stepper.Step label="Questions"></Stepper.Step>
+        <Stepper.Step label="Results"></Stepper.Step>
+      </Stepper>
+    </Box>
+  );
+}


### PR DESCRIPTION
added a progress bar that shows the current stage (or trial when relevant) that a participant is in. Also limited the number of trials for a given visit to 20, allowing participants to take the study again if there is more.

* save

* Merge branch 'dev' into feature/progress-bar
Brings dev up to date with main hotfix

* add basic progress bar

* prevent loading from taking over entire screen

* add questions label to questions

* limit to 5 questions even if more are available

* center questions when only one present

* comment

* increase limit to 20