### PR TITLE
feat: frontend timer

### DIFF
--- a/src/features/ai-study/AiStudyController.tsx
+++ b/src/features/ai-study/AiStudyController.tsx
@@ -6,14 +6,14 @@ import {
   type StimulusPair,
 } from "../../lib/stimulus";
 import { StudyProgress } from "../study/StudyProgress";
-import { Trial } from "../study/Trial";
 import { Landing } from "./Landing";
 import { Results } from "./Results";
 import { useSessionContext } from "./session/useSessionContext";
+import { Trial } from "./Trial";
 
 /**
  * AI Study Controller.
- * Currently duplicates the logic of StudyController but allows for future AI-specific overrides.
+ * Duplicates the logic of StudyController but includes AI-specific overrides.
  * Uses shared UI components from the main study feature.
  * @component
  */
@@ -53,9 +53,9 @@ export function AiStudyController() {
 
   /**
    * Processes user selection for the current trial and sends results to Supabase.
-   * @param {'left' | 'right'} choice - the graph the user selected (as being deceptive)
+   * @param {'left' | 'right' | 'none'} choice - the graph the user selected (as being deceptive)
    */
-  const handleSelect = async (choice: "left" | "right") => {
+  const handleSelect = async (choice: "left" | "right" | "none") => {
     setLoading(true);
     if (!stimulus) {
       throw new Error("cannot submit answer for invalid stimulus");
@@ -111,7 +111,13 @@ export function AiStudyController() {
   if (stage === "landing") {
     page = <Landing handleStart={handleStart} />;
   } else if (stage === "survey" && stimulus) {
-    page = <Trial stimulus={stimulus} onSelect={handleSelect}></Trial>;
+    page = (
+      <Trial
+        key={stimulus.trial_id}
+        stimulus={stimulus}
+        onSelect={handleSelect}
+      ></Trial>
+    );
   } else {
     page = <Results></Results>;
   }
@@ -123,11 +129,11 @@ export function AiStudyController() {
           num_trials={totalTrials}
           stage={stage === "survey" ? trial : stage}
         ></StudyProgress>
+        <Box pos="relative">
+          <LoadingOverlay visible={loading}></LoadingOverlay>
+          {page}
+        </Box>
       </Container>
-      <Box pos="relative">
-        <LoadingOverlay visible={loading}></LoadingOverlay>
-        {page}
-      </Box>
     </Stack>
   );
 }

--- a/src/features/ai-study/Trial.tsx
+++ b/src/features/ai-study/Trial.tsx
@@ -1,0 +1,61 @@
+import { Card, Center, Image, SimpleGrid, Space, Text } from "@mantine/core";
+import type { StimulusPair } from "../../lib/stimulus";
+
+interface TrialProps {
+  /** The pair of images to display for this trial */
+  stimulus: StimulusPair;
+
+  /**
+   * Callback to handle user answer selection.
+   * @param choice - the stimulus side selected by the user
+   */
+  onSelect: (choice: "left" | "right") => void;
+}
+
+/**
+ * A component containing an individual trial of the Visual Honesty survey
+ * @component
+ */
+export function Trial({ stimulus, onSelect }: TrialProps) {
+  return (
+    <>
+      <Center>
+        <Text size="xl">Select the deceptive visualization below</Text>
+      </Center>
+      <Space h="xl" />
+      <SimpleGrid cols={2} spacing="xl">
+        <Card
+          shadow="sm"
+          padding="lg"
+          withBorder
+          radius="lg"
+          onClick={() => onSelect("left")}
+          className="panels"
+        >
+          <Image
+            src={stimulus.left.image_url}
+            alt="Stimulus A"
+            draggable={false}
+            //TODO: Images are still selectable on Safari - need to investigate
+            style={{ userSelect: "none" }}
+          />
+        </Card>
+        <Card
+          shadow="sm"
+          padding="lg"
+          withBorder
+          radius="lg"
+          onClick={() => onSelect("right")}
+          className="panels"
+        >
+          <Image
+            src={stimulus.right.image_url}
+            alt="Stimulus B"
+            draggable={false}
+            style={{ userSelect: "none" }}
+          />
+        </Card>
+      </SimpleGrid>
+    </>
+  );
+}

--- a/src/features/study/StudyController.tsx
+++ b/src/features/study/StudyController.tsx
@@ -1,4 +1,13 @@
-import { Box, Container, LoadingOverlay, Stack } from "@mantine/core";
+import {
+  Box,
+  Button,
+  Container,
+  LoadingOverlay,
+  Modal,
+  Space,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useRef, useState } from "react";
 import {
   fetchNextPair,
@@ -17,6 +26,7 @@ import { Trial } from "./Trial";
  * @component
  */
 export function StudyController() {
+  // Participant session
   const { sessionId, initializeSession } = useSessionContext();
   // Loading state for async operations
   const [loading, setLoading] = useState<boolean>(false);
@@ -28,6 +38,7 @@ export function StudyController() {
   const [trial, setTrial] = useState<number>(0);
   const [totalTrials, setTotalTrials] = useState<number>(0);
   const [stimulus, setStimulus] = useState<StimulusPair | null>(null);
+  const [waitingContinue, setWaitingContinue] = useState(false);
   /**
    * Preloads an image into the browser cache
    * @param url - url of image to preload
@@ -52,9 +63,9 @@ export function StudyController() {
 
   /**
    * Processes user selection for the current trial and sends results to Supabase.
-   * @param {'left' | 'right'} choice - the graph the user selected (as being deceptive)
+   * @param {'left' | 'right' | 'none'} choice - the graph the user selected (as being deceptive)
    */
-  const handleSelect = async (choice: "left" | "right") => {
+  const handleSelect = async (choice: "left" | "right" | "none") => {
     setLoading(true);
     if (!stimulus) {
       throw new Error("cannot submit answer for invalid stimulus");
@@ -66,23 +77,28 @@ export function StudyController() {
       throw new Error("timekeeping error!");
     }
     await submitResponse(sessionId, stimulus, choice, timeTaken);
-    if (trial < totalTrials) {
-      const next = await fetchNextPair(sessionId);
-      if (next) {
-        await preloadStimulus(next);
-        setStimulus(next);
-        setTrial(trial + 1);
-        trialStartTime.current = performance.now();
+    if (choice === "none") {
+      // Pause the test flow if the user timed out on the last question
+      setWaitingContinue(true);
+    } else {
+      if (trial < totalTrials) {
+        const next = await fetchNextPair(sessionId);
+        if (next) {
+          await preloadStimulus(next);
+          setStimulus(next);
+          setTrial(trial + 1);
+          trialStartTime.current = performance.now();
+        } else {
+          setStage("results");
+        }
       } else {
         setStage("results");
       }
-    } else {
-      setStage("results");
     }
-
     setLoading(false);
   };
 
+  /** Starts the test and loads the first image pair */
   const handleStart = async () => {
     setLoading(true);
     if (!sessionId) {
@@ -106,12 +122,41 @@ export function StudyController() {
     setLoading(false);
   };
 
+  /**
+   * If the last trial ended in a timeout, a modal shows and we pause the flow.
+   * When run, this function continues the test flow.
+   */
+  const continueAfterTimeout = async () => {
+    setWaitingContinue(false);
+    setLoading(true);
+    if (trial < totalTrials) {
+      const next = await fetchNextPair(sessionId);
+      if (next) {
+        await preloadStimulus(next);
+        setStimulus(next);
+        setTrial(trial + 1);
+        trialStartTime.current = performance.now();
+      } else {
+        setStage("results");
+      }
+    } else {
+      setStage("results");
+    }
+    setLoading(false);
+  };
+
   let page;
 
   if (stage === "landing") {
     page = <Landing handleStart={() => handleStart()} />;
   } else if (stage === "survey" && stimulus) {
-    page = <Trial stimulus={stimulus} onSelect={handleSelect}></Trial>;
+    page = (
+      <Trial
+        key={stimulus.trial_id}
+        stimulus={stimulus}
+        onSelect={handleSelect}
+      ></Trial>
+    );
   } else {
     page = <Results></Results>;
   }
@@ -123,11 +168,24 @@ export function StudyController() {
           num_trials={totalTrials}
           stage={stage === "survey" ? trial : stage}
         ></StudyProgress>
+        {/* When timeout occurs we pause here before loading next stimulus */}
+        <Modal
+          opened={waitingContinue}
+          onClose={() => {}}
+          withCloseButton={false}
+          centered
+        >
+          <Text mb="md">You ran out of time.</Text>
+          <Button fullWidth onClick={continueAfterTimeout}>
+            Continue
+          </Button>
+        </Modal>
+        <Space h="md"></Space>
+        <Box pos="relative">
+          <LoadingOverlay visible={loading}></LoadingOverlay>
+          {page}
+        </Box>
       </Container>
-      <Box pos="relative">
-        <LoadingOverlay visible={loading}></LoadingOverlay>
-        {page}
-      </Box>
     </Stack>
   );
 }

--- a/src/features/study/Trial.tsx
+++ b/src/features/study/Trial.tsx
@@ -1,4 +1,14 @@
-import { Card, Center, Image, SimpleGrid, Space, Text } from "@mantine/core";
+import {
+  Card,
+  Center,
+  Group,
+  Image,
+  Progress,
+  SimpleGrid,
+  Space,
+  Text,
+} from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
 import type { StimulusPair } from "../../lib/stimulus";
 
 interface TrialProps {
@@ -9,7 +19,7 @@ interface TrialProps {
    * Callback to handle user answer selection.
    * @param choice - the stimulus side selected by the user
    */
-  onSelect: (choice: "left" | "right") => void;
+  onSelect: (choice: "left" | "right" | "none") => void;
 }
 
 /**
@@ -17,8 +27,69 @@ interface TrialProps {
  * @component
  */
 export function Trial({ stimulus, onSelect }: TrialProps) {
+  const [progress, setProgress] = useState(100);
+  const [timeLeftMs, setTimeLeftMs] = useState(10000);
+  const onSelectRef = useRef(onSelect);
+  const animationDurationMs = 60000;
+
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+
+  const resetKey = stimulus.trial_id;
+
+  // Kick off the visual timer and countdown text whenever a new trial loads.
+  useEffect(() => {
+    // requestAnimationFrame avoids React’s warning about synchronous setState in effects.
+    const resetProgressFrame = window.requestAnimationFrame(() =>
+      setProgress(100),
+    );
+    const resetCountdownFrame = window.requestAnimationFrame(() =>
+      setTimeLeftMs(animationDurationMs),
+    );
+    const startTimeout = window.setTimeout(() => setProgress(0), 50);
+    const deadline = performance.now() + animationDurationMs;
+    const countdownInterval = window.setInterval(() => {
+      setTimeLeftMs(Math.max(0, deadline - performance.now()));
+    }, 200);
+    const expireTimeout = window.setTimeout(() => {
+      onSelectRef.current("none");
+    }, animationDurationMs + 50);
+
+    return () => {
+      window.cancelAnimationFrame(resetProgressFrame);
+      window.cancelAnimationFrame(resetCountdownFrame);
+      window.clearTimeout(startTimeout);
+      window.clearInterval(countdownInterval);
+      window.clearTimeout(expireTimeout);
+    };
+  }, [resetKey, animationDurationMs]);
+
+  // Display whole seconds.
+  const secondsRemaining = Math.max(0, Math.ceil(timeLeftMs / 1000));
+
   return (
     <>
+      <Group
+        justify="space-between"
+        mb={4}
+        align="center"
+        style={{ width: "100%" }}
+      >
+        <Text size="sm" c="dimmed">
+          Time remaining
+        </Text>
+        <Text size="sm" fw={600}>
+          {secondsRemaining}s
+        </Text>
+      </Group>
+      <Progress
+        value={progress}
+        style={{ width: "100%", marginBottom: 16 }}
+        styles={{
+          section: { transition: `width ${animationDurationMs}ms linear` },
+        }}
+      />
       <Center>
         <Text size="xl">Select the deceptive visualization below</Text>
       </Center>
@@ -41,7 +112,6 @@ export function Trial({ stimulus, onSelect }: TrialProps) {
           />
         </Card>
         <Card
-          shadow="sm"
           padding="lg"
           withBorder
           radius="lg"

--- a/src/lib/stimulus.ts
+++ b/src/lib/stimulus.ts
@@ -77,7 +77,7 @@ export const fetchNextPair = async (
 export const submitResponse = async (
   sessionId: string,
   stimulus: StimulusPair,
-  selectedSide: "left" | "right",
+  selectedSide: "left" | "right" | "none",
   timeTaken: number,
 ) => {
   const choiceId =
@@ -86,7 +86,7 @@ export const submitResponse = async (
   const { data, error } = await supabase.rpc("submit_response", {
     p_session_id: sessionId,
     p_trial_id: stimulus.trial_id,
-    p_choice: choiceId,
+    p_choice: selectedSide === "none" ? null : choiceId,
     p_frontend_time: Math.round(timeTaken),
   });
 

--- a/supabase/migrations/20260224191607_allow null responses for timing.sql
+++ b/supabase/migrations/20260224191607_allow null responses for timing.sql
@@ -1,0 +1,259 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.create_ai_participant(p_category text, p_demographics jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_new_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM admins WHERE id = auth.uid()) THEN
+    RAISE EXCEPTION 'Access Denied: User is not an authorized administrator.';
+  END IF;
+
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (true, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_participant(p_category text DEFAULT 'human'::text, p_demographics jsonb DEFAULT '{}'::jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_new_id uuid;
+BEGIN
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (false, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_binned_benchmarks()
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_bins json;
+BEGIN
+  -- A. Aggregate stats per session (exclude AI)
+  WITH user_stats AS (
+      SELECT 
+        AVG(s.average_time) as x, 
+        SUM(s.correct_answers)::float / NULLIF(SUM(s.total_questions), 0) * 100 as y
+      FROM participant_stats s
+      GROUP BY s.session_id
+  ),
+  -- B. Quantile Binning
+  ranked_data AS (
+      SELECT 
+        x, y,
+        ntile(10) OVER (ORDER BY x) as bucket
+      FROM user_stats
+  ),
+  -- C. Calculate Stats for each Decile
+  binned_data AS (
+      SELECT 
+        bucket,
+        AVG(x) as avg_time,
+        AVG(y) as avg_accuracy,
+        STDDEV(y) as std_dev,
+        COUNT(*) as count
+      FROM ranked_data
+      GROUP BY bucket
+      ORDER BY bucket
+  )
+  -- D. Format Output
+  SELECT json_agg(
+    json_build_object(
+      'x', avg_time, 
+      'y', avg_accuracy, 
+      'range_min', GREATEST(0, avg_accuracy - COALESCE(std_dev, 0)),
+      'range_max', LEAST(100, avg_accuracy + COALESCE(std_dev, 0)),
+      'count', count
+    )
+  ) INTO v_bins FROM binned_data;
+
+  RETURN json_build_object(
+    'trend', COALESCE(v_bins, '[]'::json)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_participant_category_comparison(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  result_json json;
+BEGIN
+  -- 1. Update stats for this participant first
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. Build the JSON Array
+  SELECT 
+    json_agg(
+      json_build_object(
+        'category', p.category,
+        'user', p.accuracy_percentage,
+        'average', g1.global_accuracy,
+        'ai', g2.global_accuracy
+      )
+    )
+  INTO result_json
+  FROM participant_stats p
+  -- Join with the global view to get the averages
+  LEFT OUTER JOIN participant_category_benchmarks g1 ON p.category = g1.category
+  LEFT OUTER JOIN ai_category_benchmarks g2 ON p.category = g2.category
+  WHERE p.session_id = target_uuid;
+
+  -- 3. Return the array (or an empty array [] if no stats exist yet)
+  RETURN COALESCE(result_json, '[]'::json);
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.is_valid_participant(p_session_id uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 
+    FROM public.participants 
+    WHERE id = p_session_id
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.submit_response(p_session_id uuid, p_trial_id uuid, p_choice uuid, p_frontend_time integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$DECLARE
+  v_rows_updated INT;
+BEGIN
+  -- Validate choice belongs to the trial
+  IF p_choice IS NOT NULL AND p_choice NOT IN (
+    SELECT s.id
+    FROM stimuli s
+    JOIN responses r ON s.set_id = r.set_id
+    WHERE r.id = p_trial_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Stimulus does not belong to this question');
+  END IF;
+
+  -- Validate time
+  IF p_frontend_time IS NULL OR p_frontend_time <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid time duration');
+  END IF;
+
+  -- Update only if still pending
+  UPDATE responses
+  SET
+    selected_stimulus = p_choice,
+    time_taken = p_frontend_time,
+    completed_at = NOW()
+  WHERE
+    id = p_trial_id
+    AND session_id = p_session_id
+    AND completed_at IS NULL
+    AND time_taken IS NULL
+    AND selected_stimulus IS NULL;
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+  IF v_rows_updated = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trial not found or already completed');
+  ELSE
+    RETURN jsonb_build_object('success', true);
+  END IF;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.upsert_ai_stats(target_uuid uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'temp'
+AS $function$BEGIN
+  -- Perform the calculation and upsert in a single efficient query
+  INSERT INTO public.ai_stats (
+    session_id, 
+    category, 
+    total_questions, 
+    correct_answers, 
+    accuracy_percentage, 
+    average_time
+  )
+  SELECT
+    r.session_id,
+    st.category,  -- Get the category from the Sets table
+    COUNT(*) AS total_questions,
+    -- Keep your original logic: counting where the selected stimulus was deceptive
+    COUNT(*) FILTER (WHERE s.is_deceptive = TRUE) AS correct_answers,
+    CASE 
+      WHEN COUNT(*) > 0 
+      THEN (COUNT(*) FILTER (WHERE s.is_deceptive = TRUE)::float / COUNT(*)) * 100 
+      ELSE 0 
+    END AS accuracy_percentage,
+    AVG(r.time_taken) AS average_time
+  FROM responses r
+  -- Join 1: To check correctness
+  JOIN stimuli s ON r.selected_stimulus = s.id
+  -- Join 2: To get the category
+  JOIN sets st ON r.set_id = st.id
+  WHERE r.session_id = target_uuid
+  GROUP BY r.session_id, st.category
+  -- Upsert based on the composite key of User + Category
+  ON CONFLICT (session_id, category) 
+  DO UPDATE SET
+    total_questions = EXCLUDED.total_questions,
+    correct_answers = EXCLUDED.correct_answers,
+    accuracy_percentage = EXCLUDED.accuracy_percentage,
+    average_time = EXCLUDED.average_time;
+END;$function$
+;
+
+grant delete on table "public"."ai_stats" to "postgres";
+
+grant insert on table "public"."ai_stats" to "postgres";
+
+grant references on table "public"."ai_stats" to "postgres";
+
+grant select on table "public"."ai_stats" to "postgres";
+
+grant trigger on table "public"."ai_stats" to "postgres";
+
+grant truncate on table "public"."ai_stats" to "postgres";
+
+grant update on table "public"."ai_stats" to "postgres";
+
+grant delete on table "public"."participants" to "postgres";
+
+grant insert on table "public"."participants" to "postgres";
+
+grant references on table "public"."participants" to "postgres";
+
+grant select on table "public"."participants" to "postgres";
+
+grant trigger on table "public"."participants" to "postgres";
+
+grant truncate on table "public"."participants" to "postgres";
+
+grant update on table "public"."participants" to "postgres";
+
+

--- a/supabase/migrations/20260224195641_ai stats.sql
+++ b/supabase/migrations/20260224195641_ai stats.sql
@@ -1,0 +1,355 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_ai_results(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$DECLARE
+  -- Variables to hold the User's Aggregated Stats
+  user_total_q int;
+  user_correct_a int;
+  user_overall_acc float;
+  user_avg_time float;
+  calc_percentile float;
+  total_users int;
+BEGIN
+  -- 1. Update stats for this participant
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. AGGREGATE the target user's stats across ALL their categories
+  SELECT
+    SUM(total_questions),
+    SUM(correct_answers),
+    -- Calculate True Overall Accuracy: (Total Correct / Total Questions) * 100
+    CASE 
+      WHEN SUM(total_questions) > 0 
+      THEN ROUND((SUM(correct_answers)::float / SUM(total_questions)) * 100)
+      ELSE 0 
+    END,
+    -- Average time across all categories
+    AVG(average_time)
+  INTO 
+    user_total_q, 
+    user_correct_a, 
+    user_overall_acc, 
+    user_avg_time
+  FROM public.ai_stats 
+  WHERE session_id = target_uuid;
+
+  -- 3. Calculate Percentile: Compare User's Overall Acc vs. AI only
+  WITH ai_scores AS (
+    SELECT 
+      s.session_id,
+      CASE 
+        WHEN SUM(s.total_questions) > 0 
+        THEN (SUM(s.correct_answers)::float / SUM(s.total_questions)) * 100 
+        ELSE 0 
+      END as overall_acc
+    FROM public.ai_stats s
+    GROUP BY s.session_id
+  )
+  SELECT
+    ROUND(
+      (COUNT(*) FILTER (WHERE overall_acc <= user_overall_acc)::float / NULLIF(COUNT(*), 0)) * 100
+    ),
+    COUNT(*) - 1
+  INTO calc_percentile, total_users
+  FROM ai_scores;
+
+  -- Return as JSON
+  RETURN json_build_object(
+    'total_questions', COALESCE(user_total_q, 0),
+    'correct_answers', COALESCE(user_correct_a, 0),
+    'accuracy_percentage', COALESCE(user_overall_acc, 0),
+    'percentile', COALESCE(calc_percentile, 0),
+    'total_users', COALESCE(total_users, 0),
+    'average_time', COALESCE(user_avg_time, 0)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_ai_participant(p_category text, p_demographics jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_new_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM admins WHERE id = auth.uid()) THEN
+    RAISE EXCEPTION 'Access Denied: User is not an authorized administrator.';
+  END IF;
+
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (true, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_participant(p_category text DEFAULT 'human'::text, p_demographics jsonb DEFAULT '{}'::jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_new_id uuid;
+BEGIN
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (false, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_binned_benchmarks()
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_bins json;
+BEGIN
+  -- A. Aggregate stats per session (exclude AI)
+  WITH user_stats AS (
+      SELECT 
+        AVG(s.average_time) as x, 
+        SUM(s.correct_answers)::float / NULLIF(SUM(s.total_questions), 0) * 100 as y
+      FROM participant_stats s
+      GROUP BY s.session_id
+  ),
+  -- B. Quantile Binning
+  ranked_data AS (
+      SELECT 
+        x, y,
+        ntile(10) OVER (ORDER BY x) as bucket
+      FROM user_stats
+  ),
+  -- C. Calculate Stats for each Decile
+  binned_data AS (
+      SELECT 
+        bucket,
+        AVG(x) as avg_time,
+        AVG(y) as avg_accuracy,
+        STDDEV(y) as std_dev,
+        COUNT(*) as count
+      FROM ranked_data
+      GROUP BY bucket
+      ORDER BY bucket
+  )
+  -- D. Format Output
+  SELECT json_agg(
+    json_build_object(
+      'x', avg_time, 
+      'y', avg_accuracy, 
+      'range_min', GREATEST(0, avg_accuracy - COALESCE(std_dev, 0)),
+      'range_max', LEAST(100, avg_accuracy + COALESCE(std_dev, 0)),
+      'count', count
+    )
+  ) INTO v_bins FROM binned_data;
+
+  RETURN json_build_object(
+    'trend', COALESCE(v_bins, '[]'::json)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_participant_category_comparison(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  result_json json;
+BEGIN
+  -- 1. Update stats for this participant first
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. Build the JSON Array
+  SELECT 
+    json_agg(
+      json_build_object(
+        'category', p.category,
+        'user', p.accuracy_percentage,
+        'average', g1.global_accuracy,
+        'ai', g2.global_accuracy
+      )
+    )
+  INTO result_json
+  FROM participant_stats p
+  -- Join with the global view to get the averages
+  LEFT OUTER JOIN participant_category_benchmarks g1 ON p.category = g1.category
+  LEFT OUTER JOIN ai_category_benchmarks g2 ON p.category = g2.category
+  WHERE p.session_id = target_uuid;
+
+  -- 3. Return the array (or an empty array [] if no stats exist yet)
+  RETURN COALESCE(result_json, '[]'::json);
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_participant_results(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$DECLARE
+  -- Variables to hold the User's Aggregated Stats
+  user_total_q int;
+  user_correct_a int;
+  user_overall_acc float;
+  user_avg_time float;
+  calc_percentile float;
+  total_users int;
+BEGIN
+  IF (SELECT is_ai FROM public.participants WHERE id = target_uuid) THEN
+        RETURN public.get_ai_results(target_uuid);
+  END IF; 
+
+  -- 1. Update stats for this participant
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. AGGREGATE the target user's stats across ALL their categories
+  SELECT
+    SUM(total_questions),
+    SUM(correct_answers),
+    -- Calculate True Overall Accuracy: (Total Correct / Total Questions) * 100
+    CASE 
+      WHEN SUM(total_questions) > 0 
+      THEN ROUND((SUM(correct_answers)::float / SUM(total_questions)) * 100)
+      ELSE 0 
+    END,
+    -- Average time across all categories
+    AVG(average_time)
+  INTO 
+    user_total_q, 
+    user_correct_a, 
+    user_overall_acc, 
+    user_avg_time
+  FROM public.participant_stats 
+  WHERE session_id = target_uuid;
+
+  -- 3. Calculate Percentile: Compare User's Overall Acc vs. Humans Only
+  WITH participant_scores AS (
+    SELECT 
+      s.session_id,
+      CASE 
+        WHEN SUM(s.total_questions) > 0 
+        THEN (SUM(s.correct_answers)::float / SUM(s.total_questions)) * 100 
+        ELSE 0 
+      END as overall_acc
+    FROM public.participant_stats s
+    GROUP BY s.session_id
+  )
+  SELECT
+    ROUND(
+      (COUNT(*) FILTER (WHERE overall_acc <= user_overall_acc)::float / NULLIF(COUNT(*), 0)) * 100
+    ),
+    COUNT(*) - 1
+  INTO calc_percentile, total_users
+  FROM participant_scores;
+
+  -- Return as JSON
+  RETURN json_build_object(
+    'total_questions', COALESCE(user_total_q, 0),
+    'correct_answers', COALESCE(user_correct_a, 0),
+    'accuracy_percentage', COALESCE(user_overall_acc, 0),
+    'percentile', COALESCE(calc_percentile, 0),
+    'total_users', COALESCE(total_users, 0),
+    'average_time', COALESCE(user_avg_time, 0)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.is_valid_participant(p_session_id uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 
+    FROM public.participants 
+    WHERE id = p_session_id
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.upsert_ai_stats(target_uuid uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'temp'
+AS $function$BEGIN
+  -- Perform the calculation and upsert in a single efficient query
+  INSERT INTO public.ai_stats (
+    session_id, 
+    category, 
+    total_questions, 
+    correct_answers, 
+    accuracy_percentage, 
+    average_time
+  )
+  SELECT
+    r.session_id,
+    st.category,  -- Get the category from the Sets table
+    COUNT(*) AS total_questions,
+    -- Keep your original logic: counting where the selected stimulus was deceptive
+    COUNT(*) FILTER (WHERE s.is_deceptive = TRUE) AS correct_answers,
+    CASE 
+      WHEN COUNT(*) > 0 
+      THEN (COUNT(*) FILTER (WHERE s.is_deceptive = TRUE)::float / COUNT(*)) * 100 
+      ELSE 0 
+    END AS accuracy_percentage,
+    AVG(r.time_taken) AS average_time
+  FROM responses r
+  -- Join 1: To check correctness
+  JOIN stimuli s ON r.selected_stimulus = s.id
+  -- Join 2: To get the category
+  JOIN sets st ON r.set_id = st.id
+  WHERE r.session_id = target_uuid
+  GROUP BY r.session_id, st.category
+  -- Upsert based on the composite key of User + Category
+  ON CONFLICT (session_id, category) 
+  DO UPDATE SET
+    total_questions = EXCLUDED.total_questions,
+    correct_answers = EXCLUDED.correct_answers,
+    accuracy_percentage = EXCLUDED.accuracy_percentage,
+    average_time = EXCLUDED.average_time;
+END;$function$
+;
+
+grant delete on table "public"."ai_stats" to "postgres";
+
+grant insert on table "public"."ai_stats" to "postgres";
+
+grant references on table "public"."ai_stats" to "postgres";
+
+grant select on table "public"."ai_stats" to "postgres";
+
+grant trigger on table "public"."ai_stats" to "postgres";
+
+grant truncate on table "public"."ai_stats" to "postgres";
+
+grant update on table "public"."ai_stats" to "postgres";
+
+grant delete on table "public"."participants" to "postgres";
+
+grant insert on table "public"."participants" to "postgres";
+
+grant references on table "public"."participants" to "postgres";
+
+grant select on table "public"."participants" to "postgres";
+
+grant trigger on table "public"."participants" to "postgres";
+
+grant truncate on table "public"."participants" to "postgres";
+
+grant update on table "public"."participants" to "postgres";
+
+

--- a/supabase/migrations/20260224201128_fix stats for timed out trials.sql
+++ b/supabase/migrations/20260224201128_fix stats for timed out trials.sql
@@ -1,0 +1,331 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.create_ai_participant(p_category text, p_demographics jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_new_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM admins WHERE id = auth.uid()) THEN
+    RAISE EXCEPTION 'Access Denied: User is not an authorized administrator.';
+  END IF;
+
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (true, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_participant(p_category text DEFAULT 'human'::text, p_demographics jsonb DEFAULT '{}'::jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_new_id uuid;
+BEGIN
+  -- is_ai is hardcoded to false here, ignoring any frontend input
+  INSERT INTO public.participants (is_ai, category, demographics)
+  VALUES (false, p_category, p_demographics)
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_binned_benchmarks()
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  v_bins json;
+BEGIN
+  -- A. Aggregate stats per session (exclude AI)
+  WITH user_stats AS (
+      SELECT 
+        AVG(s.average_time) as x, 
+        SUM(s.correct_answers)::float / NULLIF(SUM(s.total_questions), 0) * 100 as y
+      FROM participant_stats s
+      GROUP BY s.session_id
+  ),
+  -- B. Quantile Binning
+  ranked_data AS (
+      SELECT 
+        x, y,
+        ntile(10) OVER (ORDER BY x) as bucket
+      FROM user_stats
+  ),
+  -- C. Calculate Stats for each Decile
+  binned_data AS (
+      SELECT 
+        bucket,
+        AVG(x) as avg_time,
+        AVG(y) as avg_accuracy,
+        STDDEV(y) as std_dev,
+        COUNT(*) as count
+      FROM ranked_data
+      GROUP BY bucket
+      ORDER BY bucket
+  )
+  -- D. Format Output
+  SELECT json_agg(
+    json_build_object(
+      'x', avg_time, 
+      'y', avg_accuracy, 
+      'range_min', GREATEST(0, avg_accuracy - COALESCE(std_dev, 0)),
+      'range_max', LEAST(100, avg_accuracy + COALESCE(std_dev, 0)),
+      'count', count
+    )
+  ) INTO v_bins FROM binned_data;
+
+  RETURN json_build_object(
+    'trend', COALESCE(v_bins, '[]'::json)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_participant_category_comparison(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$DECLARE
+  result_json json;
+BEGIN
+  -- 1. Update stats for this participant first
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. Build the JSON Array
+  SELECT 
+    json_agg(
+      json_build_object(
+        'category', p.category,
+        'user', p.accuracy_percentage,
+        'average', g1.global_accuracy,
+        'ai', g2.global_accuracy
+      )
+    )
+  INTO result_json
+  FROM participant_stats p
+  -- Join with the global view to get the averages
+  LEFT OUTER JOIN participant_category_benchmarks g1 ON p.category = g1.category
+  LEFT OUTER JOIN ai_category_benchmarks g2 ON p.category = g2.category
+  WHERE p.session_id = target_uuid;
+
+  -- 3. Return the array (or an empty array [] if no stats exist yet)
+  RETURN COALESCE(result_json, '[]'::json);
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_participant_results(target_uuid uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$DECLARE
+  -- Variables to hold the User's Aggregated Stats
+  user_total_q int;
+  user_correct_a int;
+  user_overall_acc float;
+  user_avg_time float;
+  calc_percentile float;
+  total_users int;
+BEGIN
+  IF (SELECT is_ai FROM public.participants WHERE id = target_uuid) THEN
+        RETURN public.get_ai_results(target_uuid);
+  END IF; 
+
+  -- 1. Update stats for this participant
+  PERFORM public.upsert_participant_stats(target_uuid);
+
+  -- 2. AGGREGATE the target user's stats across ALL their categories
+  SELECT
+    SUM(total_questions),
+    SUM(correct_answers),
+    -- Calculate True Overall Accuracy: (Total Correct / Total Questions) * 100
+    CASE 
+      WHEN SUM(total_questions) > 0 
+      THEN ROUND((SUM(correct_answers)::float / SUM(total_questions)) * 100)
+      ELSE 0 
+    END,
+    -- Average time across all categories
+    AVG(average_time)
+  INTO 
+    user_total_q, 
+    user_correct_a, 
+    user_overall_acc, 
+    user_avg_time
+  FROM public.participant_stats 
+  WHERE session_id = target_uuid;
+
+  -- 3. Calculate Percentile: Compare User's Overall Acc vs. Humans Only
+  WITH participant_scores AS (
+    SELECT 
+      s.session_id,
+      CASE 
+        WHEN SUM(s.total_questions) > 0 
+        THEN (SUM(s.correct_answers)::float / SUM(s.total_questions)) * 100 
+        ELSE 0 
+      END as overall_acc
+    FROM public.participant_stats s
+    GROUP BY s.session_id
+  )
+  SELECT
+    ROUND(
+      (COUNT(*) FILTER (WHERE overall_acc <= user_overall_acc)::float / NULLIF(COUNT(*), 0)) * 100
+    ),
+    COUNT(*) - 1
+  INTO calc_percentile, total_users
+  FROM participant_scores;
+
+  -- Return as JSON
+  RETURN json_build_object(
+    'total_questions', COALESCE(user_total_q, 0),
+    'correct_answers', COALESCE(user_correct_a, 0),
+    'accuracy_percentage', COALESCE(user_overall_acc, 0),
+    'percentile', COALESCE(calc_percentile, 0),
+    'total_users', COALESCE(total_users, 0),
+    'average_time', COALESCE(user_avg_time, 0)
+  );
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.is_valid_participant(p_session_id uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 
+    FROM public.participants 
+    WHERE id = p_session_id
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.upsert_ai_stats(target_uuid uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'temp'
+AS $function$BEGIN
+  INSERT INTO public.ai_stats (
+    session_id, 
+    category, 
+    total_questions, 
+    correct_answers, 
+    accuracy_percentage, 
+    average_time
+  )
+  SELECT
+    r.session_id,
+    st.category,  -- Get the category from the Sets table
+    COUNT(*) AS total_questions,
+    COUNT(*) FILTER (WHERE s.is_deceptive = TRUE) AS correct_answers,
+    CASE 
+      WHEN COUNT(*) > 0 
+      THEN (COUNT(*) FILTER (WHERE s.is_deceptive = TRUE)::float / COUNT(*)) * 100 
+      ELSE 0 
+    END AS accuracy_percentage,
+    AVG(r.time_taken) AS average_time
+  FROM responses r
+  -- Join 1: To check correctness
+  LEFT OUTER JOIN stimuli s ON r.selected_stimulus = s.id
+  -- Join 2: To get the category
+  LEFT OUTER JOIN sets st ON r.set_id = st.id
+  WHERE r.session_id = target_uuid
+  GROUP BY r.session_id, st.category
+  -- Upsert based on the composite key of User + Category
+  ON CONFLICT (session_id, category) 
+  DO UPDATE SET
+    total_questions = EXCLUDED.total_questions,
+    correct_answers = EXCLUDED.correct_answers,
+    accuracy_percentage = EXCLUDED.accuracy_percentage,
+    average_time = EXCLUDED.average_time;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.upsert_participant_stats(target_uuid uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'temp'
+AS $function$BEGIN
+  IF (SELECT is_ai FROM public.participants WHERE id = target_uuid) THEN
+        PERFORM public.upsert_ai_stats(target_uuid);
+        RETURN; -- Exit this function so the human upsert doesn't run
+  END IF;
+
+  INSERT INTO public.participant_stats (
+    session_id, 
+    category, 
+    total_questions, 
+    correct_answers, 
+    accuracy_percentage, 
+    average_time
+  )
+  SELECT
+    r.session_id,
+    st.category,  -- Get the category from the Sets table
+    COUNT(*) AS total_questions,
+    COUNT(*) FILTER (WHERE s.is_deceptive = TRUE) AS correct_answers,
+    CASE 
+      WHEN COUNT(*) > 0 
+      THEN (COUNT(*) FILTER (WHERE s.is_deceptive = TRUE)::float / COUNT(*)) * 100 
+      ELSE 0 
+    END AS accuracy_percentage,
+    AVG(r.time_taken) AS average_time
+  FROM responses r
+  -- Join 1: To check correctness
+  LEFT OUTER JOIN stimuli s ON r.selected_stimulus = s.id
+  -- Join 2: To get the category
+  LEFT OUTER JOIN sets st ON r.set_id = st.id
+  WHERE r.session_id = target_uuid
+  GROUP BY r.session_id, st.category
+  -- Upsert based on the composite key of User + Category
+  ON CONFLICT (session_id, category) 
+  DO UPDATE SET
+    total_questions = EXCLUDED.total_questions,
+    correct_answers = EXCLUDED.correct_answers,
+    accuracy_percentage = EXCLUDED.accuracy_percentage,
+    average_time = EXCLUDED.average_time;
+END;$function$
+;
+
+grant delete on table "public"."ai_stats" to "postgres";
+
+grant insert on table "public"."ai_stats" to "postgres";
+
+grant references on table "public"."ai_stats" to "postgres";
+
+grant select on table "public"."ai_stats" to "postgres";
+
+grant trigger on table "public"."ai_stats" to "postgres";
+
+grant truncate on table "public"."ai_stats" to "postgres";
+
+grant update on table "public"."ai_stats" to "postgres";
+
+grant delete on table "public"."participants" to "postgres";
+
+grant insert on table "public"."participants" to "postgres";
+
+grant references on table "public"."participants" to "postgres";
+
+grant select on table "public"."participants" to "postgres";
+
+grant trigger on table "public"."participants" to "postgres";
+
+grant truncate on table "public"."participants" to "postgres";
+
+grant update on table "public"."participants" to "postgres";
+
+


### PR DESCRIPTION
added a countdown timer to the participant frontend to add time pressure for each trial. Trials auto submit at the end of the countdown, with a message displayed to prevent the entire study running if a user leaves the page. In the backend, trials that aren't completed show up as 'NULL' for responses, meaning they are counted as incorrect but are still distinct since their submission time is not null.